### PR TITLE
Fix state-at-time command not working

### DIFF
--- a/omcb.py
+++ b/omcb.py
@@ -144,7 +144,7 @@ def state_at_time_command(args):
     apply_logs_to_state(state, log_name, date)
 
     with open(outfile, "wb") as f:
-        f.write(data.tobytes())
+        f.write(state.tobytes())
 
 def check_ffmpeg():
     """


### PR DESCRIPTION
We should be using "state" here, not "data", otherwise an error occurs when trying to use the `state-at-time` command.