### PR TITLE
Heatmaps (with logarithmic scaling), better logging, fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scripts for working with data from One Million Checkboxes
 _This data is licensed under the Creative Commons BY-SA (CC-BY-SA) license. See LICENSE for more details._
 
-This repo contains code for generating images and timelapses from the data for [One Million Checkboxes](https://en.wikipedia.org/wiki/One_Million_Checkboxes). [A separate download](https://archive.org/details/one-million-checkboxes-data) contains the (large!) dataset that these tools are designed to work with.
+This repo contains code for generating images, timelapses, and heatmaps from the data for [One Million Checkboxes](https://en.wikipedia.org/wiki/One_Million_Checkboxes). [A separate download](https://archive.org/details/one-million-checkboxes-data) contains the (large!) dataset that these tools are designed to work with.
 
 Some of those timelapses look like this:
 
@@ -44,6 +44,8 @@ To get set up with the scripts:
 5. Install dependencies (`pip install -r requirements.txt`)
 6. Run `python omcb.py` with the relevant command
 
+### Timelapse
+
 To generate a timelapse, run
 
 `python omcb.py timelapse START_DATE NUMBER_OF_HOURS -o VIDEOFILE.mp4 -i NUMBER_OF_SECONDS_PER_FRAME`
@@ -63,6 +65,18 @@ And
 `python ./omcb.py timelapse 2024-07-04T00:30:00Z 2024-07-05T00:30:00Z -o example.mp4 -i 30`
 
 Will generate a timelapse from 2024-07-04T00:30:00 to 2024-07-05T00:30:00, with a frame every 30 seconds.
+
+### Heatmap
+
+To generate a heatmap, run
+
+`python omcb.py timelapse START_DATE NUMBER_OF_HOURS -o IMAGEFILE.png -i NUMBER_OF_SECONDS_PER_DIFF_SAMPLE -l LOGARITHMIC_SCALE`
+
+For example
+
+`python ./omcb.py heatmap 2024-07-04T00:30:00Z 2024-07-05T00:30:00Z -o example.png -i 5`
+
+Will generate a heatmap for 2024-07-04T00:30:00 to 2024-07-05T00:30:00, with a difference sampled every 5 seconds.
 
 ## Data description and caveats
 [The archive](https://archive.org/details/one-million-checkboxes-data) is missing data from the first several hours after OMCB was launched. I (the creator of the site) am sorry about that! I was originally only keeping the first 1 million logs over the course of the day under the assumption that anything beyond that would indicate a bug. I failed to anticipate the popularity of the site!

--- a/omcb.py
+++ b/omcb.py
@@ -196,17 +196,8 @@ def check_ffmpeg():
         raise RuntimeError("FFmpeg is installed but not working correctly.")
 
 def image_of_state(state, outfile):
-    subprocess.run(
-            ["ffmpeg", 
-             "-f", "rawvideo", 
-             "-pix_fmt", "monob", 
-             "-video_size", "1000x1000", 
-             "-i", 
-             "-",
-             "-y", outfile], 
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            input=state.tobytes())
+    img = Image.frombytes("1", (1000, 1000), state.tobytes())
+    img.save(outfile)
 
 def image_of_heatmap(state, outfile, logarithmic):
     arr = np.array(state)

--- a/omcb.py
+++ b/omcb.py
@@ -398,7 +398,6 @@ def timelapse_command(args):
         print(f"created {outfile}")
 
 def heatmap_command(args):
-    check_ffmpeg()
     start = args.start_time
     end_function = args.end
     outfile = args.output
@@ -480,7 +479,6 @@ def heatmap_command(args):
     print("heatmap at", outfile)
 
 def image_at_time_command(args):
-    check_ffmpeg()
     date = args.datetime
     outfile = args.output
     data_path = args.data_directory
@@ -548,7 +546,7 @@ def main():
     timelapse.add_argument("-i", "--snapshot-every-i-seconds", type=int, required=False, default=DefaultValue(5), help="Create a snapshot every i seconds. Can be combined with -n (will snapshot whenever either happens)")
     timelapse.set_defaults(func=timelapse_command)
     
-    heatmap = subparsers.add_parser("heatmap", help="Create an image heatmap for a timerange (requires ffmpeg)")
+    heatmap = subparsers.add_parser("heatmap", help="Create an image heatmap for a timerange")
     heatmap.add_argument("start_time", type=parse_datetime, help="Start datetime in ISO format (YYYY-MM-DDTHH:MM:SS)")
     heatmap.add_argument("end", type=parse_datetime_or_span, help="End - either a timespan in hours, or a datetime in ISO format (YYYY-MM-DDTHH:MM:SS)")
     heatmap.add_argument("--data-directory", required=False, help="Path to directory where OMCB data is, if it's not in the standard location (default - a directory named 'omcb-data' that is a sibling of the 'scripts' dir that this script lives in")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 bitarray==2.9.2
+pillow
+numpy


### PR DESCRIPTION
This does these things:

Adds a heatmap command based on the timelapse command. This samples differences the same way timelapse samples frames then outputs them to an image based on the differences. It also has a --logarithmic option for log scaling. 

Changes logging to inline, reducing terminal spam.